### PR TITLE
Allow opting out of lazy load

### DIFF
--- a/lazy-load-responsive-images.php
+++ b/lazy-load-responsive-images.php
@@ -106,6 +106,10 @@ function lazy_load_responsive_images_modify_post_thumbnail_attr($attr, $attachme
     if (is_admin()) {
         return $attr;
     }
+  
+    if (isset($attr['data-no-lazyload'])) { 
+        return $attr; 
+    }
 
     if (isset($attr['sizes'])) {
         $data_sizes = $attr['sizes'];


### PR DESCRIPTION
By adding a `data-no-lazyload` attribute, images can be opted out of the lazy load behaviour (useful for e.g. banner images