### PR TITLE
Run post_thumbnail_html markup generation later

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -87,7 +87,7 @@ class Plugin {
 		add_filter( 'post_thumbnail_html', array(
 			$this,
 			'filter_markup',
-		), 10, 1 );
+		), 500, 1 );
 
 		// Enqueues scripts and styles.
 		add_action( 'wp_enqueue_scripts', array(


### PR DESCRIPTION
The current code breaks if used in conjunction with the Responsify WP plugin which does its filtering at priority 11.