### PR TITLE
handle rest api requests with edit context as admin requests

### DIFF
--- a/src/Helpers.php
+++ b/src/Helpers.php
@@ -71,7 +71,10 @@ class Helpers {
 				}
 			}
 		} else {
-			return false;
+			if (! defined('REST_REQUEST') || ! REST_REQUEST) {
+				return false;
+			}
+			return (isset($_REQUEST['context']) && 'edit' === $_REQUEST['context']);
 		}
 	}
 


### PR DESCRIPTION
Closes #29 

With Gutenberg dynamic blocks are requested through the rest api.
If those blocks contain images, currently these images will be replaced with the placeholder and not display correctly.

This commit checks if we are in the rest api and if the current context is edit. If so, it will not replace the images.