### PR TITLE
Fix duplicated images issue.

### DIFF
--- a/src/Plugin.php
+++ b/src/Plugin.php
@@ -132,6 +132,9 @@ class Plugin {
 			// Filter markup of the_content() calls to modify media markup for lazy loading.
 			add_filter( 'the_content', array( $this, 'filter_markup' ), 10001 );
 
+			// Filter allowed html for posts to allow <noscript> tag.
+			add_filter( 'wp_kses_allowed_html', array( $this, 'wp_kses_allowed_html' ), 10, 2 );
+
 			// Filter markup of Text widget to modify media markup for lazy loading.
 			add_filter( 'widget_text', array( $this, 'filter_markup' ) );
 
@@ -716,6 +719,24 @@ class Plugin {
 		$noscript_node->appendChild( $noscript_media_fallback_elem );
 
 		return $dom;
+	}
+
+	/**
+	 * Filter allowed html for posts.
+	 *
+	 * @param array  $allowedposttags Allowed post tags.
+	 * @param string $context         Context.
+	 *
+	 * @return array
+	 */
+	public function wp_kses_allowed_html( $allowedposttags, $context ) {
+		if ( 'post' !== $context ) {
+			return $allowedposttags;
+		}
+
+		$allowedposttags['noscript'] = [];
+
+		return $allowedposttags;
 	}
 
 	/**


### PR DESCRIPTION
The issue description is [here](https://wordpress.org/support/topic/duplicate-images-34/).

`\FlorianBrinkmann\LazyLoadResponsiveImages\Plugin::filter_markup` is called twice: via `wp_get_attachment_image` and via `the_content` filters. At the first call, `<noscript>` wrapping is created. 

But at `wp-content/plugins/ultimate-elementor/modules/posts/template-blocks/skin-style.php:315` they use `wp_kses_post()` with the returned HTML containing `<noscript>`. Tag is cleared by `wp_kses_post()`, and we have duplicated image.

To fix the issue, I have added the filter, which extends allowed HTML for posts with the `<noscript>` tag.
